### PR TITLE
Fix export to support frameAsTextLayer

### DIFF
--- a/TextLayer.coffee
+++ b/TextLayer.coffee
@@ -1,4 +1,4 @@
-class module.exports extends Layer
+class TextLayer extends Layer
 		
 	constructor: (options={}) ->
 		@doAutoSize = false
@@ -117,3 +117,6 @@ Layer::frameAsTextLayer = (properties) ->
     _.extend t,properties
     @destroy()
     t
+
+
+module.exports = TextLayer


### PR DESCRIPTION
Layer::frameAsTextLayer calls new TextLayer, which was never defined. Named class and exported the class variable instead of directly exporting the class without setting it's name.